### PR TITLE
Fix nested asyncio

### DIFF
--- a/ask_human_mcp/server.py
+++ b/ask_human_mcp/server.py
@@ -34,7 +34,7 @@ from typing import Dict, Optional, Set
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 

--- a/ask_human_mcp/server.py
+++ b/ask_human_mcp/server.py
@@ -955,7 +955,7 @@ async def run_stdio_mode(server: AskHumanServer):
     server.start_watching()
 
     try:
-        await server.mcp.run()
+        await server.mcp.run_async()
     except KeyboardInterrupt:
         logger.info("Received keyboard interrupt")
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    "fastmcp>=2.0.0",
     "watchdog>=3.0.0",
     "fastapi>=0.100.0",
     "uvicorn>=0.20.0",


### PR DESCRIPTION
You are supposed to use run_async() when you have your own asyncio task. [Here](https://gofastmcp.com/deployment/running-server#async-usage) is the official documentation. run_async is only available since FastMCP 2.0.0. So, an update of that package is needed. I have also seen the usage of run_stdio_async in another fork of your project. That should work too if you don't want to update to FastMCP 2.